### PR TITLE
Minor fix - TabError: inconsistent use of tabs and spaces in indentation

### DIFF
--- a/yggdrasil.py
+++ b/yggdrasil.py
@@ -147,7 +147,7 @@ def run_cmds(code, memory, current_node, parents, index = 0):
         return (index, current_node, parents)
 
 def main(code, argv, mem_flag, debug_flag):
-	if not code: return
+        if not code: return
         chars = list(map(lambda c: None if c == '_' else ord(c) * (c != '%'), code))
         memory = set_nodes(form_tree(chars), argv)
         current_node = memory


### PR DESCRIPTION
Embarrassingly minor fix to contribute, but it's the difference between it running and not running! At least for Python 3.9.5. My memory is that tabs/spaces only started being enforced with Python 3, and hadn't been for Python 2 and before.

Anyway, here goes nothing!